### PR TITLE
Refactor processors

### DIFF
--- a/lib/date_processor.rb
+++ b/lib/date_processor.rb
@@ -7,7 +7,6 @@ class DateProcessor
     @offset_shift_keys = "abcd"
     @counter = 0
     @offset_shift_values = {}
-    process_date
   end
 
   def square_date

--- a/lib/date_processor.rb
+++ b/lib/date_processor.rb
@@ -28,7 +28,7 @@ class DateProcessor
     end
   end
 
-  def output_key_values
+  def output_offset_values
     process_date
     @offset_shift_values
   end

--- a/lib/date_processor.rb
+++ b/lib/date_processor.rb
@@ -27,4 +27,9 @@ class DateProcessor
       @counter += 1
     end
   end
+
+  def output_key_values
+    process_date
+    @offset_shift_values
+  end
 end

--- a/lib/key_processor.rb
+++ b/lib/key_processor.rb
@@ -19,7 +19,7 @@ class KeyProcessor
     end
   end
 
-  def ouput_key_values
+  def output_key_values
     process_key
     @key_shift_values
   end

--- a/lib/key_processor.rb
+++ b/lib/key_processor.rb
@@ -6,7 +6,6 @@ class KeyProcessor
     @key_shift_keys = "abcd"
     @counter = 0
     @key_shift_values = {}
-    process_key
   end
 
   def split_input

--- a/lib/key_processor.rb
+++ b/lib/key_processor.rb
@@ -18,4 +18,9 @@ class KeyProcessor
       @counter += 1
     end
   end
+
+  def ouput_key_values
+    process_key
+    @key_shift_values
+  end
 end

--- a/lib/message_processor.rb
+++ b/lib/message_processor.rb
@@ -6,9 +6,9 @@ class MessageProcessor
               :message, :is_decryption, :output_message
   def initialize(message, key, date)
     @alphabet = ("a".."z").to_a << " "
-    @key_shift_values = KeyProcessor.new(key).key_shift_values
-    @offset_shift_values = DateProcessor.new(date).offset_shift_values
-    @message = message.downcase
+    @key_shift_values = KeyProcessor.new(key).output_key_values
+    @offset_shift_values = DateProcessor.new(date).output_offset_values
+    @message = message
     @is_decryption = false
     @output_message = ""
   end

--- a/test/date_processor_test.rb
+++ b/test/date_processor_test.rb
@@ -46,11 +46,11 @@ class DateProcessorTest < Minitest::Test
     assert_equal expected2, @date_processor2.offset_shift_values
   end
 
-  def test_it_can_run_entire_processing_and_output_key_values
+  def test_it_can_run_entire_processing_and_output_offset_values
     expected1 = {a:1, b:0, c:2, d:5}
     expected2 = {a:4, b:8, c:0, d:4}
 
-    assert_equal expected1, @date_processor1.output_key_values
-    assert_equal expected2, @date_processor2.output_key_values
+    assert_equal expected1, @date_processor1.output_offset_values
+    assert_equal expected2, @date_processor2.output_offset_values
   end
 end

--- a/test/date_processor_test.rb
+++ b/test/date_processor_test.rb
@@ -45,4 +45,12 @@ class DateProcessorTest < Minitest::Test
     assert_equal expected1, @date_processor1.offset_shift_values
     assert_equal expected2, @date_processor2.offset_shift_values
   end
+
+  def test_it_can_run_entire_processing_and_output_key_values
+    expected1 = {a:1, b:0, c:2, d:5}
+    expected2 = {a:4, b:8, c:0, d:4}
+
+    assert_equal expected1, @date_processor1.output_key_values
+    assert_equal expected2, @date_processor2.output_key_values
+  end
 end

--- a/test/key_processor_test.rb
+++ b/test/key_processor_test.rb
@@ -33,4 +33,13 @@ class KeyProcessorTest < Minitest::Test
 
     assert_equal expected, @key_processor.key_shift_values
   end
+
+  def test_it_can_process_key_and_ouput_key_values
+    expected = {a: 2,
+                b: 27,
+                c: 71,
+                d: 15}
+
+    assert_equal expected, @key_processor.ouput_key_values
+  end
 end

--- a/test/key_processor_test.rb
+++ b/test/key_processor_test.rb
@@ -34,12 +34,12 @@ class KeyProcessorTest < Minitest::Test
     assert_equal expected, @key_processor.key_shift_values
   end
 
-  def test_it_can_process_key_and_ouput_key_values
+  def test_it_can_process_key_and_output_key_values
     expected = {a: 2,
                 b: 27,
                 c: 71,
                 d: 15}
 
-    assert_equal expected, @key_processor.ouput_key_values
+    assert_equal expected, @key_processor.output_key_values
   end
 end


### PR DESCRIPTION
Needed to refactor date and key processors to not call #process_date or #process_key in the initialize. Calling it during instantiation was playing tricks on the counter and breaking the program.
- #output_offset_values created in DateProcessor for use in MessageProcessor
- #output_key_values created in KeyProcessor for use in MessageProcessor